### PR TITLE
FORGEPLUGINS-213: Fix for IllegalStateException

### DIFF
--- a/impl/src/main/java/org/jboss/forge/addon/as/ui/AbstractASWizardImpl.java
+++ b/impl/src/main/java/org/jboss/forge/addon/as/ui/AbstractASWizardImpl.java
@@ -58,9 +58,11 @@ public abstract class AbstractASWizardImpl extends AbstractProjectCommand
    @Override
    public boolean isEnabled(UIContext context)
    {
-      ApplicationServerProvider selectedProvider = getSelectedProvider(context);
-      if (selectedProvider != null && super.isEnabled(context))
-         return selectedProvider.isASInstalled(context);
+      if (super.isEnabled(context)) {
+         ApplicationServerProvider selectedProvider = getSelectedProvider(context);
+         if (selectedProvider != null)
+            return selectedProvider.isASInstalled(context);
+      }
       return false;
    }
 


### PR DESCRIPTION
A project is required in the current context when calling `getSelectedProject()`, 
therefore the best strategy is to only fetch the selected provider when `super.isEnabled() == true`
